### PR TITLE
Fix resource leaks on Unix platforms

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version_major=1
 version_minor=0
-version_patch=1
+version_patch=3
 
 # Dependencies
 gson=2.11.0

--- a/src/main/java/dev/firstdark/rpc/connection/unix/JUnixBackend.java
+++ b/src/main/java/dev/firstdark/rpc/connection/unix/JUnixBackend.java
@@ -18,8 +18,14 @@ public class JUnixBackend implements IUnixBackend {
      */
     @Override
     public void openPipe(String path) throws IOException {
-        this.socket = AFUNIXSocket.newInstance();
-        this.socket.connect(AFUNIXSocketAddress.of(new File(path)));
+        AFUNIXSocket socket = AFUNIXSocket.newInstance();
+        try {
+            socket.connect(AFUNIXSocketAddress.of(new File(path)));
+            this.socket = socket;
+        } catch (IOException e) {
+            socket.close();
+            throw e;
+        }
     }
 
     /**

--- a/src/main/java/dev/firstdark/rpc/connection/unix/NIOUnixBackend.java
+++ b/src/main/java/dev/firstdark/rpc/connection/unix/NIOUnixBackend.java
@@ -67,12 +67,14 @@ public class NIOUnixBackend implements IUnixBackend {
             return -1;
 
         Selector selector = Selector.open();
-        channel.configureBlocking(false);
-        channel.register(selector, SelectionKey.OP_READ);
-        int ready = selector.selectNow();
-        selector.close();
-        channel.configureBlocking(true);
-        return ready;
+        try {
+            channel.configureBlocking(false);
+            channel.register(selector, SelectionKey.OP_READ);
+            return selector.selectNow();
+        } finally {
+            selector.close();
+            channel.configureBlocking(true);
+        }
     }
 
     /**

--- a/src/main/java/dev/firstdark/rpc/connection/unix/NIOUnixBackend.java
+++ b/src/main/java/dev/firstdark/rpc/connection/unix/NIOUnixBackend.java
@@ -73,7 +73,13 @@ public class NIOUnixBackend implements IUnixBackend {
             return selector.selectNow();
         } finally {
             selector.close();
-            channel.configureBlocking(true);
+            try {
+                if (channel.isOpen()) {
+                    channel.configureBlocking(true);
+                }
+            } catch (IOException ignored) {
+                // Channel can be prematurely closed if an exception is thrown in the first try block
+            }
         }
     }
 


### PR DESCRIPTION
This fixes some native resource leaks which can occur in error scenarios on Unix backends:

* If an exception occurs in JUnixBackend when establishing a socket connection, file descriptors will continuously leak due to retry logic
* If an exception occurs during NIOUnixBackend's getAvailable(), Selector will leak file descriptors continuously due to retry logic

These issues have a potential to cause a denial of service on the host OS due to broken retry logic:

Although `reconnectAttempts` correctly accumulates to 10, because nextConnect is only updated after a failed connection attempt, it will infinitely run:

```
if (!this.rpcConnection.isOpen()) {
    if (this.isFirstConnect.get() || System.currentTimeMillis() >= this.nextConnect) {
        this.rpcConnection.open();  // <-- Still tries to open, even if 10 attempts exceeded!
        if (!this.isFirstConnect.get())
            this.updateReconnectTime();
    }
}
```

This should be guarded against with:

```
            private static final int MAX_RETRY_ATTEMPTS = 10;

            if (reconnectAttempts < MAX_RETRY_ATTEMPTS && (this.isFirstConnect.get() || System.currentTimeMillis() >= this.nextConnect)) {
                this.rpcConnection.open();

                if (!this.isFirstConnect.get())
                    this.updateReconnectTime();
            }
```